### PR TITLE
Fix Python3 compatibility issues.

### DIFF
--- a/python/lsst/db/engineFactory.py
+++ b/python/lsst/db/engineFactory.py
@@ -78,7 +78,10 @@ def getEngineFromFile(fileName,
     """
     fileName = os.path.expanduser(fileName)
     parser = ConfigParser()
-    parser.readfp(open(fileName), fileName)
+    with open(fileName) as config:
+        # readfp is deprecated in Python3.x, read_file is not in Python2
+        read_file = getattr(parser, "read_file", None) or getattr(parser, "readfp")
+        read_file(config, fileName)
     try:
         options = dict(parser.items("database"))
     except NoSectionError:


### PR DESCRIPTION
Fix for unicode/bytes when writing via low-level os.write call. Suppress
warning from ConfigParser which has deprecated one of the methods in
python3.